### PR TITLE
Remove patch version from go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tnagatomi/gh-mrlabel
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/cli/go-gh/v2 v2.5.0


### PR DESCRIPTION
For `cli/gh-extension-precompile@v1` to succeed.

Error log: https://github.com/tnagatomi/gh-mrlabel/actions/runs/8036402845/job/21950056150